### PR TITLE
Post to channels and one small bug fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func readAnonymousMessage(r *http.Request) string {
 	if err != nil {
 		return "Failed to send message."
 	}
-	return fmt.Sprintf("Anonymously sent [%s] to %s", user, msg)
+	return fmt.Sprintf("Anonymously sent %s to [%s]", msg, user)
 }
 
 // sendAnonymousMessage uses an incoming hook to Direct Message

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ var (
 		"rhino", "sheep", "shrew", "skunk", "slow loris", "squirrel", "turtle", "walrus", "wolf", "wolverine", "wombat",
 	}
 	// Username must be first.
-	payloadExp = regexp.MustCompile(`(@[^\s]+):?(.*)`)
+	payloadExp = regexp.MustCompile(`([@#][^\s]+):?(.*)`)
 )
 
 // readAnonymousMessage parses the username and re-routes


### PR DESCRIPTION
I added two small improvements:
- The message use to be "Anonymously sent [%s] to %s", but this was slightly incorrect. For example, this would return "Anonymously sent [@sandlerben] to hi there." Now it will return "Anonymously sent hi there to [@sandlerben]."
- I added the ability for users to post secret messages to channels as well as users. Slack incoming webhooks [supports this](https://api.slack.com/incoming-webhooks).
